### PR TITLE
fix: Add shebang to shell script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env sh
+
 elm-package install && elm-live src/Main.elm --open --pushstate --dir=static --docs=static/docs.json --output=static/elm.js


### PR DESCRIPTION
Fixes the following error in `start.sh`

> Failed to execute process './start.sh'. Reason:
>exec: Exec format error
>The file './start.sh' is marked as an executable but could not be run by the operating system.
